### PR TITLE
Example runner via github pages

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install TeX Live
         uses: zauguin/install-texlive@v4
+        with:
+          package_file: .github/tl_packages
       - run: tex xbeamer.ins
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: zauguin/install-texlive@v4
         with:
           package_file: .github/tl_packages
-      - run: tex xbeamer.ins
+      - run: tex xbeamer.ins && cp *.cls examples
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install TeX Live
+        uses: zauguin/install-texlive@v4
+      - run: tex xbeamer.ins
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll

--- a/examples/index.md
+++ b/examples/index.md
@@ -15,7 +15,7 @@
 <pre class="norun" markdown="1">
 
 ```latex
-{% include_relative xbeamer.cls %}
+{% include_relative ../xbeamer.cls %}
 ```
 
 </pre>

--- a/examples/index.md
+++ b/examples/index.md
@@ -15,7 +15,7 @@
 <pre class="norun" markdown="1">
 
 ```latex
-{% include_relative beamer.cls %}
+{% include_relative xbeamer.cls %}
 ```
 
 </pre>

--- a/examples/index.md
+++ b/examples/index.md
@@ -2,7 +2,27 @@
 ---
 
 <script src="https://texlive.net/cm6-test/cm6.bundle.min.js"></script>
-<script src="https://texlive.net/runlatex-cm6.js"></script>
+<script src="https://texlive.net/runlatex2-cm6.js"></script>
+<script>
+function generatepreamble(t,e) {return e.getValue();}
+      runlatex.overleafURI=null;
+      
+      runlatex.texts ={
+	  "Open in Overleaf": "",
+	  "TeXLive.net":      "Generate Tagged PDF", 
+	  "Delete Output":    "Delete Output",
+	  "Compiling PDF":    "Compiling Tagged PDF",
+          "Added Code":       "",
+	  "End Added Code":   "",
+	  "Top Caption":      "",
+	  "metadata":         ""
+      }
+
+runlatex.editorlines=45;
+runlatex.preincludes = {
+ "pre0": {"pre1": "xbeamer.cls"},
+ }
+</script>
 
 ## footer-text.tex
 
@@ -12,9 +32,9 @@
 
 
 
-<pre class="norun" markdown="1">
+<pre class="norun" style="height:6em" markdown="1">
 
-```latex
+```
 {% include_relative xbeamer.cls %}
 ```
 

--- a/examples/index.md
+++ b/examples/index.md
@@ -20,7 +20,8 @@ function generatepreamble(t,e) {return e.getValue();}
 
 runlatex.editorlines=45;
 runlatex.preincludes = {
- "pre0": {"pre1": "xbeamer.cls"},
+ "pre0": {"pre2": "xbeamer.cls"},
+ "pre1": {"pre2": "xbeamer.cls"},
  }
 </script>
 
@@ -30,13 +31,17 @@ runlatex.preincludes = {
 {% include_relative footer-text.tex %}
 ```
 
+## header-footer-color.tex
+
+```latex
+{% include_relative header-footer-color.tex %}
+```
+
 
 
 <pre class="norun" style="height:6em" markdown="1">
 
-```
 {% include_relative xbeamer.cls %}
-```
 
 </pre>
 

--- a/examples/index.md
+++ b/examples/index.md
@@ -1,6 +1,9 @@
 ---
 ---
 
+
+{% assign examples = site.static_files | where_exp:"item","item.path contains '/examples/'" | where_exp:"item","item.path contains '.tex'" %}
+
 <script src="https://texlive.net/cm6-test/cm6.bundle.min.js"></script>
 <script src="https://texlive.net/runlatex2-cm6.js"></script>
 <script>
@@ -19,27 +22,32 @@ function generatepreamble(t,e) {return e.getValue();}
       }
 
 runlatex.editorlines=45;
+
+
 runlatex.preincludes = {
- "pre0": {"pre2": "xbeamer.cls"},
- "pre1": {"pre2": "xbeamer.cls"},
- }
+{% for e in examples %}
+ "pre{{forloop.index0}}": {"pre{{examples.size}}": "xbeamer.cls"},
+{% endfor %}
+}
 </script>
 
-## footer-text.tex
+# XBeamer Examples
+
+{% for e in examples %}
+
+## {{e.basename}}
 
 ```latex
-{% include_relative footer-text.tex %}
+{% include_relative {{e.name}} %}
 ```
 
-## header-footer-color.tex
-
-```latex
-{% include_relative header-footer-color.tex %}
-```
+{% endfor %}
 
 
 
-<pre class="norun" style="height:6em" markdown="1">
+## `xbeamer.cls`
+
+<pre class="norun" style="height:8em" markdown="1">
 
 {% include_relative xbeamer.cls %}
 

--- a/examples/index.md
+++ b/examples/index.md
@@ -1,0 +1,22 @@
+---
+---
+
+<script src="https://texlive.net/cm6-test/cm6.bundle.min.js"></script>
+<script src="https://texlive.net/runlatex-cm6.js"></script>
+
+## footer-text.tex
+
+```latex
+{% include_relative footer-text.tex %}
+```
+
+
+
+<pre class="norun" markdown="1">
+
+```latex
+{% include_relative beamer.cls %}
+```
+
+</pre>
+

--- a/examples/index.md
+++ b/examples/index.md
@@ -15,7 +15,7 @@
 <pre class="norun" markdown="1">
 
 ```latex
-{% include_relative ../xbeamer.cls %}
+{% include_relative xbeamer.cls %}
 ```
 
 </pre>


### PR DESCRIPTION

This PR adds a gh-pages workflow (I think you'd have to separately enable gh-pages in the settings to build pages via github actions)  so you get an xbeamer gh-pages site.

It sets up examples/index.html to show each example file with a texlive.net runner to to open in ngpdf or show_pdf_tags.

It is a bit inefficient currently as it is setup as a separate github action pipeline to the main pipeline, which means that the l3build artifacts are not available, so it has to install texlive to run xbeamer.ins to get hold of the class.

an alternative would be not to do that and arrange separately that the class was installed at texlive.net (perhaps via a cron job pulling from github) but this is OK for now I think.

You can view the result at

https://davidcarlisle.github.io/xbeamer/examples/

It dynamically adjusts to any examples in that directory. Currently it assumes it only needs to upload `xbeamer.cls` in addition to each document, although it could be adjusted to upload more (or as noted above we could make xbeamer available in other ways)

